### PR TITLE
Pyro Changes

### DIFF
--- a/.other/src/java.sim.nocompile/edu/mit/rocket_team/zephyrus/util/data/RTPyroStatus.java
+++ b/.other/src/java.sim.nocompile/edu/mit/rocket_team/zephyrus/util/data/RTPyroStatus.java
@@ -1,14 +1,12 @@
 package edu.mit.rocket_team.zephyrus.util.data;
 
 public enum RTPyroStatus {
-    PYRO_FAILURE(1),
-    PYRO_UNCONNECTED(2),
-    PYRO_CONNECTED(3),
-    PYRO_ARMED(4),
-    PYRO_SUCCESS(5),
-    PYRO_FIRING(6);
+    PYRO_FAILURE(0),
+    PYRO_UNCONNECTED(1),
+    PYRO_CONNECTED(2),
+    PYRO_SUCCESS(3);
 
-    public int ID = -1;
+    public int ID = 0;
 
     RTPyroStatus(int ID) {
         this.ID = ID;

--- a/.other/src/java.sim.nocompile/edu/mit/rocket_team/zephyrus/util/data/RTState.java
+++ b/.other/src/java.sim.nocompile/edu/mit/rocket_team/zephyrus/util/data/RTState.java
@@ -1,0 +1,16 @@
+package edu.mit.rocket_team.zephyrus.util.data;
+
+public enum RTState {
+    GROUND_TESTING(0),
+    PRE_FLIGHT(1),
+    FLIGHT(2),
+    APOGEE(3),
+    DISREEF(4),
+    END(5);
+
+    public int ID = 0;
+
+    RTState(int ID) {
+        this.ID = ID;
+    }
+}


### PR DESCRIPTION
Changes to Pyro Library to match FC Code as close as possible.
Addition of RTState enum -- will be needed later anyway.
shouldMisfire array should be set if we want to sim a misfire.
hasFire is helper to emulate hardware.